### PR TITLE
add a count operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,13 @@ script:
     - 'python3 pyhedrals/pyhedrals.py -v "12d6ro>=4 # reroll once on >=4"'
     - 'python3 pyhedrals/pyhedrals.py -v "12d6ro<4 # reroll once on <4"'
     - 'python3 pyhedrals/pyhedrals.py -v "12d6ro<=4 # reroll once on <=4"'
+    # count
+    - 'python3 pyhedrals/pyhedrals.py -v "12d10c # count maximum"'
+    - 'python3 pyhedrals/pyhedrals.py -v "12d10c1 # count 1s"'
+    - 'python3 pyhedrals/pyhedrals.py -v "12d10c>8 # count where >8"'
+    - 'python3 pyhedrals/pyhedrals.py -v "12d10c>=8 # count where >=8"'
+    - 'python3 pyhedrals/pyhedrals.py -v "12d10c<4 # count where <4"'
+    - 'python3 pyhedrals/pyhedrals.py -v "12d10c<= # count where <=4"'
     # sorting
     - 'python3 pyhedrals/pyhedrals.py -v "10d10s # sort (ascending)"'
     - 'python3 pyhedrals/pyhedrals.py -v "10d10sa # sort ascending"'

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ There is also a verbose mode that outputs every individual die roll, that output
   * Reroll: `r` `r#` `r>#` `r>=#` `r<#` `r<=#`
     * Drops and rerolls each die that rolls minimum (`r`), or a specific number (`r#`), or over/under a threshold (`r>#` `r>=#` `r<#` `r<=#`)
       * This repeats for each die rerolled. You can make it only reroll each die once with `ro` instead of `r`
+  * Count: `c` `c#` `c>#` `c>=#` `c<#` `c<=#`
+    * Counts the number of dice that roll maximum (`c`), or a specific number (`r#`), or over/under a threshold (`r># `r>=#` `r<#` `r<=#`)
   * Sorting: `s` `sa` `sd`
     * Sorts the dice rolls in ascending (`s` `sa`) or descending (`sd`) order
     * This still applies in non-verbose mode but you won't see any visible effect


### PR DESCRIPTION
When a RollList expression has the count operator attached, don't sum the dice: Instead, count the number of dice that satisfy the comparison.

There's some shared logic between this and other comparison-based operators. Let me know if you'd like me to include a refactor in this PR to reduce duplication.